### PR TITLE
Fix tags in April 2016 post

### DIFF
--- a/source/_posts/2016-04-19-going-serverless.md
+++ b/source/_posts/2016-04-19-going-serverless.md
@@ -1,9 +1,7 @@
 layout: post
 title: "Meeting: April 19 - Going Serverless"
 comments: true
-tags:
-  - Jeremy Green
-  - Serverless
+tags: [Jeremy Green, Serverless]
 date: 2016-04-19
 ---
 


### PR DESCRIPTION
The tag contents were correct and displayed appropriately. However, using list format instead of an array, throw off the markdown for <!-- more --> sections and font formats for bulleted lists.