### PR TITLE
Upgrade Hexo and remove deprecated or incompatible packages

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -78,18 +78,7 @@ pagination_dir: page
 # Disqus
 disqus_shortname: okcjs
 
-# Extensions
-## Plugins: https://github.com/hexojs/hexo/wiki/Plugins
-plugins:
-- hexo-broken-link-checker
-
-# hexo-broken-link-checker plugin
-link_checker:
-  enabled: false
-  storage_dir: temp/link_checker
-  silent_logs: false
-
-## Themes: https://github.com/hexojs/hexo/wiki/Themes
+# Themes: https://github.com/hexojs/hexo/wiki/Themes
 theme: okcjs
 exclude_generator:
 

--- a/package.json
+++ b/package.json
@@ -2,31 +2,20 @@
   "name": "hexo-site",
   "version": "2.7.1",
   "private": true,
+  "hexo": {
+    "version": "3.2.2"
+  },
   "dependencies": {
-    "hexo": "^3.0.0",
-    "hexo-deployer-git": "0.0.x",
-    "hexo-front-matter": "0.2.x",
-    "hexo-generator-archive": "0.1.x",
-    "hexo-generator-category": "0.1.x",
-    "hexo-generator-feed": "*",
-    "hexo-generator-index": "0.1.x",
-    "hexo-generator-minify": "0.1.x",
-    "hexo-generator-sitemap": "*",
-    "hexo-generator-tag": "0.1.x",
-    "hexo-pagination": "0.0.x",
+    "hexo": "^3.2.0",
+    "hexo-generator-archive": "^0.1.4",
+    "hexo-generator-category": "^0.1.3",
+    "hexo-generator-feed": "^1.2.0",
+    "hexo-generator-index": "^0.2.0",
+    "hexo-generator-tag": "^0.2.0",
     "hexo-renderer-ejs": "*",
-    "hexo-renderer-markdownjs": "0.0.x",
     "hexo-renderer-marked": "*",
     "hexo-renderer-stylus": "*",
-    "hexo-server": "0.1.x",
-    "hexo-tag-googlemaps": "*",
-    "hexo-util": "0.1.x"
-  },
-  "hexo": {
-    "version": "3.1.1"
-  },
-  "devDependencies": {
-    "async": "^1.5.2",
-    "hexo-broken-link-checker": "1.0.x"
+    "hexo-server": "^0.2.0",
+    "hexo-tag-googlemaps": "*"
   }
 }


### PR DESCRIPTION
I upgraded Node to v.6 and started receiving weird warning messages when updated Hexo websites. I upgraded Hexo on my system and this appears to have fixed that but also has forced me to review our node packages for compatability.